### PR TITLE
chore: ignore cypress folder videos and screenshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+/cypress/screenshots/
+/cypress/videos/


### PR DESCRIPTION
Adicionado ao arquivo .gitignore as pastas locais geradas pelo cypress
- Pasta para videos
- Pasta para screenshots