### PR TITLE
fix: resolve windows bug at default format file in crlf to lf

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true


### PR DESCRIPTION
A formatação de arquivos do Windows e sistemas baseados em linux são diferentes 
Então como muitos de vocês podem sofrer com esse tipo de problema, tive que resolver isso rápido 
- O arquivo adicionado troca a formato CRLF padrão para LF  