### PR TITLE
fix: [add] .env file in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ yarn-error.log*
 .pnpm-debug.log*
 
 # local env files
+.env
 .env*.local
 
 # vercel


### PR DESCRIPTION
No arquivo .gitignore existe o seguinte trecho:

.env*.local

Que supostamente deveria ignorar todos os arquivos .env, para não correr o risco de mandar arquivos de teste junto com PRs.

Porem, essa linha não dá suporte ao arquio .env, sem qualquer outro texto. Então a modifiquei para:

.env
.env*.local