### PR TITLE
fix: format file theme css to pass when running linter

### DIFF
--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -108,5 +108,4 @@ body {
   border: solid 1px var(--default);
   color: var(--default);
   box-sizing: border-box;
-  }
-
+}


### PR DESCRIPTION
Resolvido bug que ao passar o linter, ele falhava
- O bug era na formatação do arquivo theme.css 