### PR TITLE
feat/add-descriptive-names-to-http-codes

### DIFF
--- a/lib/statusCode.ts
+++ b/lib/statusCode.ts
@@ -1,0 +1,77 @@
+enum CodeInformational {
+  Continue = 100,
+  SwitchingProtocols,
+  Processing,
+}
+
+enum CodeSuccess {
+  OK = 200,
+  Created,
+  Accepted,
+  NonAuthoritativeInformation,
+  NoContent,
+  ResetContent,
+  PartialContent,
+  MultiStatus,
+  AlreadyReported,
+  IMUsed = 226,
+}
+
+enum CodeRedirection {
+  MultipleChoices = 300,
+  MovedPermanently,
+  Found,
+  SeeOther,
+  NotModified,
+  UseProxy,
+  TemporaryRedirect,
+  PermanentRedirect,
+}
+
+enum CodeClientError {
+  BadRequest = 400,
+  Unauthorized,
+  PaymentRequired,
+  Forbidden,
+  NotFound,
+  MethodNotAllowed,
+  NotAcceptable,
+  ProxyAuthenticationRequired,
+  RequestTimeout,
+  Conflict,
+  Gone,
+  LengthRequired,
+  PreconditionFailed,
+  PayloadTooLarge,
+  RequestURITooLong,
+  UnsupportedMediaType,
+  RequestedRangeNotSatisfiable,
+  ExpectationFailed,
+  ImTeapot,
+  MisdirectedRequest = 421,
+  UnprocessableEntity,
+  Locked,
+  FailedDependency,
+  UpgradeRequired = 426,
+  PreconditionRequired = 428,
+  TooManyRequests,
+  RequestHeaderFieldsTooLarge = 431,
+  ConnectionClosedWithoutResponse = 444,
+  UnavailableForLegalReasons = 451,
+  ClientClosedRequest = 499,
+}
+
+enum CodeServerError {
+  InternalServerError = 500,
+  NotImplemented,
+  BadGateway,
+  ServiceUnavailable,
+  GatewayTimeout,
+  HTTPVersionNotSupported,
+  VariantAlsoNegociates,
+  InsufficientStorage,
+  LoopDetected,
+  NotExtended = 510,
+  NetworkAuthenticationRequired,
+  NetworkConnectionTimeoutError = 599,
+}


### PR DESCRIPTION
Ficar lembrando qual o número que representa determinado código HTTP não é prático.

Acaba sendo melhor utilizar nomes descritivos, que no final se traduzem nos ditos códigos.