### PR TITLE
feat/api-route-protection-pattern

### DIFF
--- a/docs/ProtectedAPI.md
+++ b/docs/ProtectedAPI.md
@@ -1,0 +1,57 @@
+# Definição da Proteção das API's
+
+## authGuard
+
+O `authGuard` é um módulo responsável por garantir que as solicitações sejam autorizadas antes de prosseguir. Ele usa o `httpVerbGuard` para verificar se a solicitação HTTP está dentro de uma lista de métodos aceitos. Em seguida, ele usa o Supabase para atualizar a sessão do usuário e retornar a sessão e o usuário se for bem-sucedido.
+
+### Uso
+
+```typescript
+import { NextApiRequest, NextApiResponse } from 'next'
+import { auth, httpVerb } from './authGuard'
+
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { token } = await auth(req, res, httpVerb.GET, httpVerb.POST)
+  if (!token) return
+  
+  // Continue com a lógica do seu handler
+}
+```
+
+### Parâmetros
+
+- `req: NextApiRequest` - O objeto de solicitação do Next.js
+- `res: NextApiResponse` - O objeto de resposta do Next.js
+- `httpVerbs: httpVerb[]` - Uma lista de métodos HTTP aceitos
+
+### Retorno
+
+O método `auth` retorna um objeto contendo a sessão e o usuário se a solicitação estiver autorizada. Se a solicitação não estiver autorizada, ele retorna uma resposta HTTP com o código de status apropriado e uma mensagem de erro.
+
+## httpVerbGuard
+
+O `httpVerbGuard` é um módulo que verifica se o método HTTP de uma solicitação está dentro de uma lista especificada de métodos aceitos.
+
+### Uso
+
+```typescript
+import { NextApiRequest, NextApiResponse } from 'next'
+import { httpVerbGuard, httpVerb } from './httpVerbGuard'
+
+function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { released } = httpVerbGuard(req, res, httpVerb.GET, httpVerb.POST)
+  if (!released) return
+  
+  // Continue com a lógica do seu handler
+}
+```
+
+### Parâmetros
+
+- `req: NextApiRequest` - O objeto de solicitação do Next.js
+- `res: NextApiResponse` - O objeto de resposta do Next.js
+- `httpVerbs: httpVerb[]` - Uma lista de métodos HTTP aceitos
+
+### Retorno
+
+O método `httpVerbGuard` retorna o objeto de resposta do Next.js se a solicitação estiver dentro dos limites dos métodos HTTP aceitos. Se a solicitação não estiver dentro dos limites, ele retorna uma resposta HTTP com o código de status apropriado e uma mensagem de erro.

--- a/docs/ProtectedAPI.md
+++ b/docs/ProtectedAPI.md
@@ -13,7 +13,7 @@ import { auth, httpVerb } from './authGuard'
 async function handler(req: NextApiRequest, res: NextApiResponse) {
   const { token } = await auth(req, res, httpVerb.GET, httpVerb.POST)
   if (!token) return
-  
+
   // Continue com a lógica do seu handler
 }
 ```
@@ -41,7 +41,7 @@ import { httpVerbGuard, httpVerb } from './httpVerbGuard'
 function handler(req: NextApiRequest, res: NextApiResponse) {
   const { released } = httpVerbGuard(req, res, httpVerb.GET, httpVerb.POST)
   if (!released) return
-  
+
   // Continue com a lógica do seu handler
 }
 ```

--- a/lib/authGuard.ts
+++ b/lib/authGuard.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 import { supabase } from './connection'
-import { httpVerb, httpVerbGuard } from './httpVerbGuard'
+import { guard, httpVerb } from './httpVerbGuard'
 import { CodeClientError } from './statusCode'
 
 export async function auth(
@@ -8,7 +8,7 @@ export async function auth(
   res: NextApiResponse,
   ...httpVerbs: httpVerb[]
 ) {
-  const released = httpVerbGuard(req, res, ...httpVerbs)
+  const released = guard(req, res, ...httpVerbs)
   if (!released) return
 
   let token = req.body.session as {

--- a/lib/authGuard.ts
+++ b/lib/authGuard.ts
@@ -1,0 +1,36 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import { supabase } from './connection'
+import { httpVerb, httpVerbGuard } from './httpVerbGuard'
+import { CodeClientError } from './statusCode'
+
+export async function auth(
+  req: NextApiRequest,
+  res: NextApiResponse,
+  ...httpVerbs: httpVerb[]
+) {
+  const released = httpVerbGuard(req, res, ...httpVerbs)
+  if (!released) return
+
+  let token = req.body.session as {
+    refresh_token: string
+  }
+
+  if (!token) {
+    return res
+      .status(CodeClientError.BadRequest)
+      .json({ message: 'BadRequest' })
+  }
+
+  const {
+    data: { user, session },
+    error,
+  } = await supabase.auth.refreshSession(token)
+
+  if (error) {
+    return res
+      .status(CodeClientError.Unauthorized)
+      .json({ message: 'Unauthorized' })
+  }
+
+  return { session, user }
+}

--- a/lib/httpVerbGuard.ts
+++ b/lib/httpVerbGuard.ts
@@ -1,0 +1,28 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import { CodeClientError } from './statusCode'
+
+export type httpVerb =
+  | 'GET'
+  | 'HEAD'
+  | 'POST'
+  | 'PUT'
+  | 'DELETE'
+  | 'CONNECT'
+  | 'OPTIONS'
+  | 'TRACE'
+  | 'PATCH'
+
+export function httpVerbGuard(
+  req: NextApiRequest,
+  res: NextApiResponse,
+  ...httpVerbs: httpVerb[]
+) {
+  // Verificando se a requisição está dentro do limite de httpVerbs
+  if (httpVerbs && !httpVerbs.includes(req.method! as httpVerb)) {
+    return res
+      .status(CodeClientError.MethodNotAllowed)
+      .json({ message: 'Method not allowed' })
+  }
+
+  return { res }
+}

--- a/lib/httpVerbGuard.ts
+++ b/lib/httpVerbGuard.ts
@@ -12,7 +12,7 @@ export type httpVerb =
   | 'TRACE'
   | 'PATCH'
 
-export function httpVerbGuard(
+export function guard(
   req: NextApiRequest,
   res: NextApiResponse,
   ...httpVerbs: httpVerb[]


### PR DESCRIPTION
O authGuard é responsável por garantir que as solicitações sejam autorizadas antes de prosseguir e usa o httpVerbGuard para verificar se a solicitação HTTP está dentro de uma lista de métodos aceitos. Já o httpVerbGuard é um módulo que verifica se o método HTTP de uma solicitação está dentro de uma lista especificada de métodos aceitos. A documentação inclui exemplos de uso, parâmetros e retornos para ambas as funções.