### PR TITLE
feat/add endpoint to list profiles

### DIFF
--- a/src/pages/api/v1/profiles/list.ts
+++ b/src/pages/api/v1/profiles/list.ts
@@ -1,0 +1,22 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import { supabase } from '~/lib/connection'
+import { guard } from '~/lib/httpVerbGuard'
+import { CodeServerError, CodeSuccess } from '~/lib/statusCode'
+
+export default async function handler(
+  _req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const resolved = guard(_req, res, 'GET')
+  if (!resolved) return
+
+  const { data, error } = await supabase.from('profiles').select('*')
+
+  if (error) {
+    return res.status(CodeServerError.InternalServerError).json({
+      message: error.message,
+    })
+  }
+
+  return res.status(CodeSuccess.OK).json(data)
+}


### PR DESCRIPTION
// TODO: Criar interface para o objeto retornado em `data` e usá-la para tipar o retorno da função. Isso irá aumentar a segurança e a clareza do código.

Este commit adiciona um novo endpoint para listagem de perfis (`list.ts`), que utiliza o método `GET` para recuperar todos os perfis armazenados no banco de dados Supabase por meio da função `supabase.from('profiles').select('*')`. Em caso de erro, o endpoint retorna uma mensagem de erro com o status code HTTP correspondente. Em caso de sucesso, o endpoint retorna um objeto JSON com os dados de todos os perfis cadastrados no banco de dados.